### PR TITLE
Fix issue with css classes having leading integers. Invalid in CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The editor should work in current versions of Chrome, Firefox, Safari, Opera, an
 - Standalone tool for building JSON representations of XML schemas (see the xsd/ folder in this project)
 
 ## How to use
+
+### Installing
+* (Manual Way) Download the package and include the file jquery.xmleditor.js after jQuery in the head of your web page.
+* Alternatively projects using bower can install it from the bower registry: bower install jquery.xmleditor
+
 ### Locating schema files
 Due to restrictions web browsers have on cross domain requests in javascript, all necessary XSD files must be located in the same domain as the page the editor is embedded in.  
 But rather than lugging the XSD files around everywhere, you can precompile a JSON representation of your schemas to include instead.  

--- a/jquery.xmleditor.js
+++ b/jquery.xmleditor.js
@@ -3035,7 +3035,7 @@ XMLElement.prototype.render = function(parentElement, recursive, relativeToXMLEl
 	this.domNode = document.createElement('div');
 	var $domNode = $(this.domNode);
 	this.domNode.id = this.domNodeID;
-	this.domNode.className = this.objectType.ns + "_" + this.objectType.localName + 'Instance ' + xmlElementClass;
+	this.domNode.className = this.objectType.localName + "_" + this.objectType.ns  + 'Instance ' + xmlElementClass;
 	if (this.isTopLevel)
 		this.domNode.className += ' ' + topLevelContainerClass;
 	if (this.isRootElement)
@@ -3065,7 +3065,7 @@ XMLElement.prototype.render = function(parentElement, recursive, relativeToXMLEl
 	if (this.objectType.schema)
 		this.elementName = this.xmlNode[0].tagName;
 	else {
-		this.elementName = this.editor.xmlState.namespaces.getNamespacePrefix(this.objectType.namespace) 
+		this.elementName = this.editor.xmlState.namespaces.getNamespacePrefix(this.objectType.namespace)
 		+ this.objectType.localName;
 	}
 	

--- a/src/xml_element.js
+++ b/src/xml_element.js
@@ -59,7 +59,7 @@ XMLElement.prototype.render = function(parentElement, recursive, relativeToXMLEl
 	this.domNode = document.createElement('div');
 	var $domNode = $(this.domNode);
 	this.domNode.id = this.domNodeID;
-	this.domNode.className = this.objectType.ns + "_" + this.objectType.localName + 'Instance ' + xmlElementClass;
+	this.domNode.className = this.objectType.localName + "_" + this.objectType.ns  + 'Instance ' + xmlElementClass;
 	if (this.isTopLevel)
 		this.domNode.className += ' ' + topLevelContainerClass;
 	if (this.isRootElement)
@@ -89,7 +89,7 @@ XMLElement.prototype.render = function(parentElement, recursive, relativeToXMLEl
 	if (this.objectType.schema)
 		this.elementName = this.xmlNode[0].tagName;
 	else {
-		this.elementName = this.editor.xmlState.namespaces.getNamespacePrefix(this.objectType.namespace) 
+		this.elementName = this.editor.xmlState.namespaces.getNamespacePrefix(this.objectType.namespace)
 		+ this.objectType.localName;
 	}
 	


### PR DESCRIPTION
Simply reverse the ordering namespace and localName