### PR TITLE
Name sometimes comes in with a namespace. localName doesn't seem to have this issue

### DIFF
--- a/jquery.xmleditor.js
+++ b/jquery.xmleditor.js
@@ -3470,8 +3470,9 @@ XMLElement.prototype.addAttribute = function (objectType) {
 };
 
 // Remove an attribute of type objectType from this element
+// "name" seems to come in with a namespace sometimes, localName does not.
 XMLElement.prototype.removeAttribute = function (objectType) {
-	this.xmlNode[0].removeAttribute(objectType.name);
+	this.xmlNode[0].removeAttribute(objectType.localName);
 };
 
 // Get the dom node for the currently selected attribute in this element

--- a/jquery.xmleditor.js
+++ b/jquery.xmleditor.js
@@ -3472,7 +3472,17 @@ XMLElement.prototype.addAttribute = function (objectType) {
 // Remove an attribute of type objectType from this element
 // "name" seems to come in with a namespace sometimes, localName does not.
 XMLElement.prototype.removeAttribute = function (objectType) {
-	this.xmlNode[0].removeAttribute(objectType.localName);
+	var node = this.xmlNode[0];
+	var localName = objectType.localName;
+	var has_ns = node.hasAttributeNS(objectType.namespace, localName);
+
+	if(has_ns) {
+		var attr_name = objectType.name.split(':');
+		node.removeAttributeNS(objectType.namespace, localName);
+		node.removeAttribute("xmlns:" + attr_name[0]);
+	} else {
+		node.removeAttribute(localName);
+	}
 };
 
 // Get the dom node for the currently selected attribute in this element

--- a/src/xml_element.js
+++ b/src/xml_element.js
@@ -496,7 +496,17 @@ XMLElement.prototype.addAttribute = function (objectType) {
 // Remove an attribute of type objectType from this element
 // "name" seems to come in with a namespace sometimes, localName does not.
 XMLElement.prototype.removeAttribute = function (objectType) {
-	this.xmlNode[0].removeAttribute(objectType.localName);
+	var node = this.xmlNode[0];
+	var localName = objectType.localName;
+	var has_ns = node.hasAttributeNS(objectType.namespace, localName);
+
+	if(has_ns) {
+		var attr_name = objectType.name.split(':');
+		node.removeAttributeNS(objectType.namespace, localName);
+		node.removeAttribute("xmlns:" + attr_name[0]);
+	} else {
+		node.removeAttribute(localName);
+	}
 };
 
 // Get the dom node for the currently selected attribute in this element

--- a/src/xml_element.js
+++ b/src/xml_element.js
@@ -494,8 +494,9 @@ XMLElement.prototype.addAttribute = function (objectType) {
 };
 
 // Remove an attribute of type objectType from this element
+// "name" seems to come in with a namespace sometimes, localName does not.
 XMLElement.prototype.removeAttribute = function (objectType) {
-	this.xmlNode[0].removeAttribute(objectType.name);
+	this.xmlNode[0].removeAttribute(objectType.localName);
 };
 
 // Get the dom node for the currently selected attribute in this element


### PR DESCRIPTION
Example Element:
```xml
<RequirementGroup Number="4">
```
Name: Requirements:Number
LocalName: Number