### PR TITLE
xsd2json: For phantomjs use the xsd2json source files instead of the minified build (#92)

### DIFF
--- a/xsd/build.html
+++ b/xsd/build.html
@@ -5,7 +5,9 @@
     <script src="./lib/jquery.min.js"></script>
     <script src="./lib/cycle.js"></script>
     <script src="./lib/vkbeautify.js"></script>
-    <script src="./xsd2json.js"></script>
+    <script src="./src/schema_processor.js"></script>
+    <script src="./src/schema_manager.js"></script>
+    <script src="./src/xsd2json.js"></script>
   </head>
   <body>
 


### PR DESCRIPTION
This fixes #92.